### PR TITLE
add GPU capabilities to inference server

### DIFF
--- a/E2E-demo/Serve_Pet_Classifier.ipynb
+++ b/E2E-demo/Serve_Pet_Classifier.ipynb
@@ -33,17 +33,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "7919e148-bae4-4f1d-b503-11826fc30cff",
    "metadata": {},
    "outputs": [],
    "source": [
-    "@serve.deployment(route_prefix=\"/image_predict\")\n",
+    "@serve.deployment(route_prefix=\"/image_predict\", name=\"pet_image\", ray_actor_options={\"num_gpus\": 0.5})\n",
     "class ImageModel:\n",
     "    \n",
     "    def __init__(self):\n",
     "        self.model = torch.jit.load(\"ray_model_scripted.pt\", \n",
-    "                                    map_location=torch.device('cpu'))\n",
+    "                                    map_location=torch.device('cuda:0'))\n",
     "        self.preprocessor = Compose([Resize((64,64)),\n",
     "                                     ToTensor()])\n",
     "        \n",
@@ -57,7 +57,7 @@
     "        input_tensor = torch.reshape(input_tensor, (1,3,64,64))\n",
     "        \n",
     "        with torch.no_grad():\n",
-    "            output_tensor = self.model(input_tensor)\n",
+    "            output_tensor = self.model(input_tensor.to(\"cuda\"))\n",
     "            \n",
     "        return int(torch.argmax(output_tensor[0]))"
    ]
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "270a354a-d436-4f66-96bc-60b8109aac4b",
    "metadata": {},
    "outputs": [],
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "6a44a887-2a5e-44e4-b205-7360b442201d",
    "metadata": {},
    "outputs": [
@@ -103,8 +103,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[2m\u001b[36m(HTTPProxyActor pid=2344)\u001b[0m INFO:     Started server process [2344]\n",
-      "\u001b[2m\u001b[36m(ServeController pid=2309)\u001b[0m INFO 2022-08-17 20:33:46,624 controller 2309 deployment_state.py:1216 - Adding 1 replicas to deployment 'ImageModel'.\n"
+      "\u001b[2m\u001b[36m(HTTPProxyActor pid=3316)\u001b[0m INFO:     Started server process [3316]\n",
+      "\u001b[2m\u001b[36m(ServeController pid=3281)\u001b[0m INFO 2022-08-22 18:32:28,758 controller 3281 deployment_state.py:1216 - Adding 1 replicas to deployment 'pet_image'.\n"
      ]
     }
    ],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "52151fee-9b32-4518-9b4d-2d4292653736",
    "metadata": {},
    "outputs": [],
@@ -126,18 +126,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "a64de413-83ec-4204-a3f0-2dac5e9541f5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resp = requests.post(f\"http://{host}:8000/image_predict\", data=b)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "f747590e-6f09-4176-8363-66dfc633d1d6",
    "metadata": {},
    "outputs": [
     {
@@ -149,12 +139,33 @@
     }
    ],
    "source": [
+    "resp = requests.post(f\"http://{host}:8000/image_predict\", data=b)\n",
     "print(f\"Predicted Class: {resp.json()}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "9dadf1b6-60dc-4fd6-a2e5-6bed5d9588a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicted Class: 20\n"
+     ]
+    }
+   ],
+   "source": [
+    "external_route = \"<RAY-SERVE-ROUTE>/image_predict\"\n",
+    "resp = requests.post(external_route, data=b)\n",
+    "print(f\"Predicted Class: {resp.json()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "id": "06301fa6-cdc7-4c81-a900-7e92e623ad4e",
    "metadata": {},
    "outputs": [
@@ -165,7 +176,7 @@
        "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=500x373>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This PR adds a couple of small changed to the 'Serve Pet Classifier' notebook. Primarily it adds the ability to use the available GPU's in our cluster at inference. Secondarily, it adds a second inference test that uses the external route to our inference server in addition to the internal route. 

Closes #11 