### PR TITLE
Added files to build small test image

### DIFF
--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -1,0 +1,6 @@
+FROM python:3.8.14-slim
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
+COPY ./tests /tests
+WORKDIR /tests
+ENTRYPOINT [ "/bin/bash" ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,11 @@
+app_name = ray-tests
+
+
+build-test:
+		@sudo podman build -t $(app_name) .. -f tests/Containerfile
+
+build-test-no-cache:
+		@sudo podman build -t $(app_name) .. --no-cache -f tests/Containerfile
+
+run-test:
+		@sudo podman run -it $(app_name)

--- a/tests/ray_tests.py
+++ b/tests/ray_tests.py
@@ -1,0 +1,20 @@
+import os
+import ray
+from collections import Counter
+import platform
+import time
+
+ray.init('ray://ray-cluster-example-ray-head:10001')
+print("Connected to ray cluster") 
+print("Running example ray job ...")
+
+@ray.remote
+def f(x):
+    t = sum(list(range(100000)))
+    return x + (platform.node(), )
+
+out = Counter(ray.get([f.remote(()) for _ in range(1000)]))
+
+assert len(dict(out).keys()) == 2
+
+print("Simple tests passed")


### PR DESCRIPTION
This PR adds a`tests` directory with a small `.py` script that connects to an example ray cluster, runs a small job, and checks that we have spawned 2 ray nodes. 

I've also added a `Containerfile` and a `Makefile` so we can build this test into an image that we can run to evaluate our Ray deployment on OpenShift. 