### PR TITLE
fix typo in cluster template

### DIFF
--- a/E2E-demo/example.env
+++ b/E2E-demo/example.env
@@ -1,10 +1,12 @@
-SERVER=<insert-api-serve>
-PROJECT=<insert-project-name>
-TOKEN=<insert-token>
-USER_NAME=<insert-user-name>
-RAY_CLUSTER_NAME=<insert-ray-cluster-name>
-CPU_REQUEST=<insert-cpu-request>
-CPU_LIMIT=<instert-cpu-limit>
-MEMORY_REQUEST=<insert-memory-request>
-MEMORY_LIMIT=<insert-memory-request>
-GPU_LIMIT=<instert-gpu-request>
+SERVER=<insert-api-server> # This is the URI of your OpenShift cluster.
+PROJECT=<insert-project-name> # This is the OpenShift namespace you're working in. 
+TOKEN=<insert-token> # This is your OpenShift Token.
+USER_NAME=<insert-user-name> # This is your OpenShift username. 
+RAY_CLUSTER_NAME=<insert-ray-cluster-name> # This can be any name you choose.
+
+# Below are some reasonable defaults, please update if needed.   
+CPU_REQUEST=1
+CPU_LIMIT=4
+MEMORY_REQUEST=1Gi
+MEMORY_LIMIT=6Gi
+GPU_LIMIT=0

--- a/E2E-demo/ray_cluster_control.py
+++ b/E2E-demo/ray_cluster_control.py
@@ -17,8 +17,6 @@ memory_limit = os.environ["MEMORY_LIMIT"]
 gpu_limit = os.environ["GPU_LIMIT"]
 
 
-oc.update_api_resources()
-
 def start_ray_cluster(cluster_name=cluster_name):
     os.environ["RAY_CLUSTER_NAME"] = cluster_name
     with oc.api_server(server):

--- a/deploy/cluster_collection/cluster_template.yaml
+++ b/deploy/cluster_collection/cluster_template.yaml
@@ -73,7 +73,7 @@ spec:
               # the object store size is not set manually, ray will
               # allocate a very large object store in each pod that may
               # cause problems for other pods.
-              memory: {{ memory_limit }}Gi
+              memory: {{ memory_limit }}
               nvidia.com/gpu: {{ gpu_limit }}
   - name: worker-nodes
     # we can parameterize this when we fix the JH launcher json/jinja bug
@@ -106,10 +106,10 @@ spec:
           resources:
             requests:
               cpu: {{ cpu_request }}
-              memory: {{ memory_request }}Gi
+              memory: {{ memory_request }}
             limits:
               cpu: {{ cpu_limit }}
-              memory: {{ memory_limit }}Gi
+              memory: {{ memory_limit }}
               nvidia.com/gpu: {{ gpu_limit }}
   # Commands to start Ray on the head node. You don't need to change this.
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.


### PR DESCRIPTION
Removed the units "Gi" from the template so that users can use whatever memory unit they prefer when defining their ray cluster. 

Also added some reasonable defaults to the example.env file. 